### PR TITLE
Fix scale_colour_thekids default palette

### DIFF
--- a/R/scale_thekids.R
+++ b/R/scale_thekids.R
@@ -40,7 +40,7 @@ scale_fill_thekids <- function(palette = "primary",
 
 #' @rdname scale_thekids
 #' @export
-scale_colour_thekids <- function(palette = "saffron",
+scale_colour_thekids <- function(palette = "primary",
                                 discrete = TRUE, 
                                 reverse = FALSE,
                                 begin=0, 

--- a/man/scale_thekids.Rd
+++ b/man/scale_thekids.Rd
@@ -18,7 +18,7 @@ scale_fill_thekids(
 )
 
 scale_colour_thekids(
-  palette = "saffron",
+  palette = "primary",
   discrete = TRUE,
   reverse = FALSE,
   begin = 0,
@@ -28,7 +28,7 @@ scale_colour_thekids(
 )
 
 scale_color_thekids(
-  palette = "saffron",
+  palette = "primary",
   discrete = TRUE,
   reverse = FALSE,
   begin = 0,

--- a/tests/testthat/test-scale_colour_thekids.R
+++ b/tests/testthat/test-scale_colour_thekids.R
@@ -43,6 +43,15 @@ test_that("palette is applied correctly for discrete scale", {
   expect_equal(actual, expected)
 })
 
+test_that("scale_colour_thekids() defaults to the primary palette", {
+  expected <- thekids_pal("primary", TRUE, FALSE)(3)
+
+  scale <- scale_colour_thekids()
+  actual <- scale$palette(3)
+
+  expect_equal(actual, expected)
+})
+
 
 test_that("invalid palette throws error", {
   expect_error(


### PR DESCRIPTION
## Summary
- Change `scale_colour_thekids()` default palette from `saffron` to `primary`
- Update the generated Rd usage for `scale_colour_thekids()` and `scale_color_thekids()`
- Add a regression test that the no-argument colour scale uses the primary palette

Closes #100.

## Testing
- `git diff --check`
- Not run: R/testthat suite, because this environment does not have R installed (`R: command not found`).